### PR TITLE
Add editlang null check

### DIFF
--- a/NBrightCore/common/Utils.cs
+++ b/NBrightCore/common/Utils.cs
@@ -185,7 +185,7 @@ namespace NBrightCore.common
 
         public static string FormatToSave(string inpData, TypeCode dataTyp, string editlang)
         {
-            if (editlang == "") editlang = GetCurrentCulture();
+            if (string.IsNullOrWhiteSpace(editlang)) editlang = GetCurrentCulture();
             if (String.IsNullOrEmpty(inpData))
                 return inpData;
             switch (dataTyp)


### PR DESCRIPTION
Getting an error on installs because the string for editlang was null.  May be a install specific configuration or data issue but including a null check fixes it.