### PR TITLE
Escape dd selectedtext attributes

### DIFF
--- a/NBrightCore/render/GenXmlFunctions.cs
+++ b/NBrightCore/render/GenXmlFunctions.cs
@@ -1683,7 +1683,7 @@ namespace NBrightCore.render
                             var dataTyp = "";
                             if (nod.Attributes != null && (nod.Attributes["dt"] != null)) dataTyp = nod.Attributes["dt"].InnerText;
 
-                            var selText = nod.InnerText;
+                            var selText = System.Security.SecurityElement.Escape(nod.InnerText);
 
                             if (!String.IsNullOrEmpty(originalXml))
                             {


### PR DESCRIPTION
Escaping the selectedtext attributes to allow for ampersands in category names.  Fixes https://github.com/openstore-ecommerce/OpenStore/issues/146